### PR TITLE
Update bootnode address format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ sudo nano genesis.json
 // look for "bootnodes" and update the below contents of the genesis.json
 ...
 "bootnodes": [
-"/ip4/bootnode1.polygonsupernet.arianee.net/tcp/10001/p2p/16Uiu2HAm2ZGC6fkLwmY4pJDBJEqFouTsQ6izStEaYRom7uGzGFTE"
+"/dns4/bootnode1.polygonsupernet.arianee.net/tcp/10001/p2p/16Uiu2HAm2ZGC6fkLwmY4pJDBJEqFouTsQ6izStEaYRom7uGzGFTE"
 ]
 ...
 
@@ -395,7 +395,7 @@ sudo nano genesis.json
 // look for "bootnodes" and update the below contents of the genesis.json
 ...
 "bootnodes": [
-"/ip4/bootnode1.polygonsupernet.arianee.net/tcp/10001/p2p/16Uiu2HAm2ZGC6fkLwmY4pJDBJEqFouTsQ6izStEaYRom7uGzGFTE"
+"/dns4/bootnode1.polygonsupernet.arianee.net/tcp/10001/p2p/16Uiu2HAm2ZGC6fkLwmY4pJDBJEqFouTsQ6izStEaYRom7uGzGFTE"
 ]
 ...
 


### PR DESCRIPTION
This pull request updates the bootnode address format in the README.md file to utilize DNS resolution (/dns4/) instead of IP resolution (/ip4/). The previous IP-based address was causing confusion and was not functioning as expected. By making this change, the README now accurately reflects the correct method for specifying the bootnode address, ensuring better clarity and usability for users.